### PR TITLE
private dialog view model, message view model

### DIFF
--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample.xcodeproj/project.pbxproj
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample.xcodeproj/project.pbxproj
@@ -31,7 +31,9 @@
 		2DFA31FF1B66CB020064EB94 /* TabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA31FE1B66CB020064EB94 /* TabBarController.m */; };
 		2DFA32021B66CC4D0064EB94 /* TabBarViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA32011B66CC4D0064EB94 /* TabBarViewModel.m */; };
 		2DFA32101B67D8520064EB94 /* PrivateDialogViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA320F1B67D8520064EB94 /* PrivateDialogViewModel.m */; };
+		2DFA32131B67D8640064EB94 /* ConversationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA32121B67D8640064EB94 /* ConversationViewController.m */; };
 		2DFA32161B67D8830064EB94 /* MessageViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA32151B67D8830064EB94 /* MessageViewModel.m */; };
+		2DFA321C1B6821830064EB94 /* BackButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA321B1B6821830064EB94 /* BackButtonItem.m */; };
 		DC622D4610592A32A176F399 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 302F48B23BEC552C62023089 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -93,8 +95,13 @@
 		2DFA32031B66D4010064EB94 /* TabBarItemViewControllerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TabBarItemViewControllerProtocol.h; path = Protocols/TabBarItemViewControllerProtocol.h; sourceTree = "<group>"; };
 		2DFA320E1B67D8520064EB94 /* PrivateDialogViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrivateDialogViewModel.h; sourceTree = "<group>"; };
 		2DFA320F1B67D8520064EB94 /* PrivateDialogViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrivateDialogViewModel.m; sourceTree = "<group>"; };
+		2DFA32111B67D8640064EB94 /* ConversationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConversationViewController.h; sourceTree = "<group>"; };
+		2DFA32121B67D8640064EB94 /* ConversationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConversationViewController.m; sourceTree = "<group>"; };
 		2DFA32141B67D8830064EB94 /* MessageViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageViewModel.h; sourceTree = "<group>"; };
 		2DFA32151B67D8830064EB94 /* MessageViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessageViewModel.m; sourceTree = "<group>"; };
+		2DFA32181B67E48E0064EB94 /* UserTableViewCellDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UserTableViewCellDelegate.h; path = Cells/Delegates/UserTableViewCellDelegate.h; sourceTree = "<group>"; };
+		2DFA321A1B6821830064EB94 /* BackButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BackButtonItem.h; path = "WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.h"; sourceTree = SOURCE_ROOT; };
+		2DFA321B1B6821830064EB94 /* BackButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BackButtonItem.m; path = "WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.m"; sourceTree = SOURCE_ROOT; };
 		302F48B23BEC552C62023089 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		67470EC5E95331021AE14C20 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -181,6 +188,7 @@
 			children = (
 				2DFA31ED1B66BE6A0064EB94 /* Cells */,
 				2DFA31D31B66964C0064EB94 /* UIKit categories */,
+				2DFA32191B6820F40064EB94 /* UIKit Extensions */,
 				2D8C102C1B5073D3000DAE2C /* Foundation categories */,
 				2DAAC1EA1B5038230032584C /* AppDelegate */,
 				2DAAC1ED1B5038230032584C /* Services */,
@@ -272,6 +280,8 @@
 				2DFA31DF1B669DFB0064EB94 /* UserListTableViewController.m */,
 				2DFA31FD1B66CB020064EB94 /* TabBarController.h */,
 				2DFA31FE1B66CB020064EB94 /* TabBarController.m */,
+				2DFA32111B67D8640064EB94 /* ConversationViewController.h */,
+				2DFA32121B67D8640064EB94 /* ConversationViewController.m */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -279,6 +289,7 @@
 		2DFA31ED1B66BE6A0064EB94 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				2DFA32171B67E46D0064EB94 /* Delegates */,
 				2DFA31EE1B66BE740064EB94 /* UserTableViewCell */,
 			);
 			name = Cells;
@@ -300,6 +311,24 @@
 				2DFA32031B66D4010064EB94 /* TabBarItemViewControllerProtocol.h */,
 			);
 			name = Protocol;
+			sourceTree = "<group>";
+		};
+		2DFA32171B67E46D0064EB94 /* Delegates */ = {
+			isa = PBXGroup;
+			children = (
+				2DFA32181B67E48E0064EB94 /* UserTableViewCellDelegate.h */,
+			);
+			name = Delegates;
+			sourceTree = "<group>";
+		};
+		2DFA32191B6820F40064EB94 /* UIKit Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				2DFA321A1B6821830064EB94 /* BackButtonItem.h */,
+				2DFA321B1B6821830064EB94 /* BackButtonItem.m */,
+			);
+			name = "UIKit Extensions";
+			path = "UIKit categories";
 			sourceTree = "<group>";
 		};
 		FCC6580AF82AD9046EB98A29 /* Pods */ = {
@@ -460,6 +489,8 @@
 				2DFA31D21B66963C0064EB94 /* Application.m in Sources */,
 				2D8C102A1B5072C1000DAE2C /* LoginViewModel.m in Sources */,
 				2DFA31DA1B669AC90064EB94 /* LoginViewController.m in Sources */,
+				2DFA321C1B6821830064EB94 /* BackButtonItem.m in Sources */,
+				2DFA32131B67D8640064EB94 /* ConversationViewController.m in Sources */,
 				2DFA32021B66CC4D0064EB94 /* TabBarViewModel.m in Sources */,
 				2DAAC1C01B5036440032584C /* main.m in Sources */,
 				2DFA31D61B66964C0064EB94 /* UIView+MakeToast.m in Sources */,
@@ -536,7 +567,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -574,7 +604,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample.xcodeproj/project.pbxproj
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		2DFA31FC1B66C8D30064EB94 /* UINavigationController+RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA31FB1B66C8D30064EB94 /* UINavigationController+RootViewController.m */; };
 		2DFA31FF1B66CB020064EB94 /* TabBarController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA31FE1B66CB020064EB94 /* TabBarController.m */; };
 		2DFA32021B66CC4D0064EB94 /* TabBarViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA32011B66CC4D0064EB94 /* TabBarViewModel.m */; };
+		2DFA32101B67D8520064EB94 /* PrivateDialogViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA320F1B67D8520064EB94 /* PrivateDialogViewModel.m */; };
+		2DFA32161B67D8830064EB94 /* MessageViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA32151B67D8830064EB94 /* MessageViewModel.m */; };
 		DC622D4610592A32A176F399 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 302F48B23BEC552C62023089 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -89,6 +91,10 @@
 		2DFA32001B66CC4D0064EB94 /* TabBarViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TabBarViewModel.h; sourceTree = "<group>"; };
 		2DFA32011B66CC4D0064EB94 /* TabBarViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TabBarViewModel.m; sourceTree = "<group>"; };
 		2DFA32031B66D4010064EB94 /* TabBarItemViewControllerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TabBarItemViewControllerProtocol.h; path = Protocols/TabBarItemViewControllerProtocol.h; sourceTree = "<group>"; };
+		2DFA320E1B67D8520064EB94 /* PrivateDialogViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrivateDialogViewModel.h; sourceTree = "<group>"; };
+		2DFA320F1B67D8520064EB94 /* PrivateDialogViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrivateDialogViewModel.m; sourceTree = "<group>"; };
+		2DFA32141B67D8830064EB94 /* MessageViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageViewModel.h; sourceTree = "<group>"; };
+		2DFA32151B67D8830064EB94 /* MessageViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessageViewModel.m; sourceTree = "<group>"; };
 		302F48B23BEC552C62023089 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		67470EC5E95331021AE14C20 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -133,6 +139,10 @@
 				2DFA31E21B66A0500064EB94 /* CollectionViewModel.m */,
 				2DFA32001B66CC4D0064EB94 /* TabBarViewModel.h */,
 				2DFA32011B66CC4D0064EB94 /* TabBarViewModel.m */,
+				2DFA320E1B67D8520064EB94 /* PrivateDialogViewModel.h */,
+				2DFA320F1B67D8520064EB94 /* PrivateDialogViewModel.m */,
+				2DFA32141B67D8830064EB94 /* MessageViewModel.h */,
+				2DFA32151B67D8830064EB94 /* MessageViewModel.m */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -438,6 +448,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DFA32101B67D8520064EB94 /* PrivateDialogViewModel.m in Sources */,
 				2DFA31F61B66C0C40064EB94 /* UITableViewController+RegisterNib.m in Sources */,
 				2DFA31F11B66BE9F0064EB94 /* UserTableViewCell.m in Sources */,
 				2DFA31FF1B66CB020064EB94 /* TabBarController.m in Sources */,
@@ -454,6 +465,7 @@
 				2DFA31D61B66964C0064EB94 /* UIView+MakeToast.m in Sources */,
 				2D8C102B1B5072C1000DAE2C /* UserViewModel.m in Sources */,
 				2DFA31DD1B669DEB0064EB94 /* UserListViewModel.m in Sources */,
+				2DFA32161B67D8830064EB94 /* MessageViewModel.m in Sources */,
 				2DFA31E01B669DFB0064EB94 /* UserListTableViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -525,6 +537,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -562,6 +575,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/Delegates/UserTableViewCellDelegate.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/Delegates/UserTableViewCellDelegate.h
@@ -1,0 +1,15 @@
+//
+//  UserTableViewCellDelegate.h
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol UserTableViewCellDelegate <NSObject>
+
+- (void)didPressTalk:(UIButton *)sender;
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/UserTableViewCell/UserTableViewCell.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/UserTableViewCell/UserTableViewCell.h
@@ -8,9 +8,10 @@
 
 #import <UIKit/UIKit.h>
 #import "UserViewModel.h"
+#import "UserTableViewCellDelegate.h"
 
 @interface UserTableViewCell : UITableViewCell
 
-- (void)populateWithViewModel:(UserViewModel *)viewModel;
+- (void)populateWithViewModel:(UserViewModel *)viewModel delegate:(id<UserTableViewCellDelegate>)delegate indexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/UserTableViewCell/UserTableViewCell.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Cells/UserTableViewCell/UserTableViewCell.m
@@ -13,13 +13,19 @@
 @property (weak, nonatomic) IBOutlet UILabel *nameLabel;
 @property (weak, nonatomic) IBOutlet UIButton *talkButton;
 
+@property (weak, nonatomic) id<UserTableViewCellDelegate> delegate;
+
 @end
 
 @implementation UserTableViewCell
 
-- (void)populateWithViewModel:(UserViewModel *)viewModel {
+- (void)populateWithViewModel:(UserViewModel *)viewModel delegate:(id<UserTableViewCellDelegate>)delegate indexPath:(NSIndexPath *)indexPath {
+    self.delegate = delegate;
+    
     self.nameLabel.text = viewModel.email;
     [self.talkButton setTitle:viewModel.talkButtonTitle forState:UIControlStateNormal];
+    self.talkButton.tag = indexPath.row;
+    [self.talkButton addTarget:self.delegate action:@selector(didPressTalk:) forControlEvents:UIControlEventTouchUpInside];
 }
 
 @end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Localizable.strings
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Localizable.strings
@@ -19,3 +19,6 @@
 "conversation_list_title" = "conversationes";
 "conversation_fetching_error" = "hubo un error. Intente nuevamente más tarde.";
 "talk_button_title" = "Conversar";
+"message_fetching_error" = "hubo un error. Intente nuevamente más tarde.";
+"create_dialog_error" = "hubo un error creando la conversación. Intente nuevamente más tarde.";
+"back" = "volver";

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Services/WLXQuickBloxUtils.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Services/WLXQuickBloxUtils.h
@@ -17,6 +17,11 @@
 
 #define QBPush @"QBPush"
 
+extern NSString *const QBGroupChatMessageReceivedNotification;
+extern NSString *const QBGroupChatMessageCreationFailedNotification;
+extern NSString *const QBPrivateChatMessageReceivedNotification;
+extern NSString *const QBPrivateChatMessageCreationFailedNotification;
+
 typedef enum {
     DialogTypePublicGroup = 1,
     DialogTypeGroup = 2,
@@ -95,12 +100,14 @@ typedef enum {
  
  @param occupants The dialog's occupants IDs.
  @param type The dialog type, represented by the enum type DialogType
+ @param type The dialog name
  @param success A block object to be executed after the dialog is successfully created. This block has no return value and takes one argument: a QBChatDialog.
  @param failure A block object to be executed when the creation of the dialog fails. This block has no return value and takes one argument: a NSError.
  */
 
 - (void)createDialogWithOccupants:(NSArray *)occupants
                        dialogType:(DialogType)type
+                       dialogName:(NSString *)name
                           success:(void(^)(QBChatDialog *))success
                           failure:(void(^)(NSError *))failure;
 
@@ -142,7 +149,7 @@ typedef enum {
  
  @param page The requested page's number.
  @param amount The maximum amount of records to fetch.
-@param queryParams Extra parameters. Can be nil. Parameters should be formatted as QuickBlox documentation indicates.
+ @param queryParams Extra parameters. Can be nil. Parameters should be formatted as QuickBlox documentation indicates.
  @param success A block object to be executed when the request finishes successfully. This block has no return value and takes one argument: a NSArray
  @param failure A block object to be executed when the request fails. This block has no return value and takes one argument: a NSError.
  */
@@ -156,11 +163,11 @@ typedef enum {
  Sends message to a chat
  
  @warning Quickblocks provides no callback for request's success or failure. This is handled by delegates that fire notifications.
-          "groupChatMessageCreated" or "privateChatMessageCreated" notification is fired when the message was 
+          QBGroupChatMessageReceivedNotification or QBPrivateChatMessageReceivedNotification notification is fired when the message was
             successfully sent.
             It sends the QBChatMessage in the userInfo dictionary.
  
-          "groupChatMessageCreationFailed" or "privateChatMessageCreationFailed" notification is fired when the message could not be sent.
+          QBGroupChatMessageCreationFailed or QBPrivateChatMessageCreationFailed notification is fired when the message could not be sent.
             It sends an NSError in the userInfo dictionary.
 
  @param text The message text to send.
@@ -206,6 +213,15 @@ typedef enum {
  @return YES if the user is logged in, NO otherwise.
  */
 - (BOOL)userIsLoggedIn;
+
+
+/**
+ Returns the current logged user
+ 
+ @return QBUUser representing the logged user.
+ */
+- (QBUUser *)currentUser;
+
 
 /**
  Subscribes user for receiving remote notifications.

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Storyboards/Main.storyboard
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/Storyboards/Main.storyboard
@@ -134,10 +134,31 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="DJC-Bp-R9m"/>
+                    <connections>
+                        <segue destination="uNQ-X1-BH1" kind="show" identifier="startConversationSegue" id="Alu-Bi-PyT"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QFs-ce-f76" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1324" y="24"/>
+        </scene>
+        <!--Conversation View Controller-->
+        <scene sceneID="lZi-od-IYQ">
+            <objects>
+                <viewController hidesBottomBarWhenPushed="YES" id="uNQ-X1-BH1" customClass="ConversationViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="kVJ-L4-d6M"/>
+                        <viewControllerLayoutGuide type="bottom" id="1fX-jP-HmE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="TK8-ZX-Kg7">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="siS-SN-sOx" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2291" y="24"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="loR-RK-NTb">

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.h
@@ -1,0 +1,13 @@
+//
+//  BackButtonItem.h
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BackButtonItem : UIBarButtonItem
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/UIKit Extensions/BackButtonItem.m
@@ -1,0 +1,22 @@
+//
+//  BackButtonItem.m
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import "BackButtonItem.h"
+#import "NSString+CapitalizeFirstWord.h"
+
+@implementation BackButtonItem
+
++ (BackButtonItem *)new {
+    BackButtonItem *item = [[BackButtonItem alloc] initWithTitle:[NSLocalizedString(@"back", nil) capitalizeFirstWord]
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:nil
+                                                            action:nil];
+    return item;
+}
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewControllers/ConversationViewController.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewControllers/ConversationViewController.h
@@ -1,0 +1,16 @@
+//
+//  ConversationViewController.h
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import "JSQMessagesViewController.h"
+#import "PrivateDialogViewModel.h"
+
+@interface ConversationViewController : JSQMessagesViewController
+
+@property (strong, nonatomic) PrivateDialogViewModel *viewModel;
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewControllers/ConversationViewController.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewControllers/ConversationViewController.m
@@ -1,0 +1,184 @@
+//
+//  ConversationViewController.m
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import "ConversationViewController.h"
+
+#import "JSQMessages.h"
+
+#import "UIView+MakeToast.h"
+
+NSUInteger const MessagesBetweenDates = 3;
+
+@interface ConversationViewController ()
+
+@property (strong, nonatomic) UITapGestureRecognizer *recognizer;
+@property (strong, nonatomic) JSQMessagesBubbleImage *outgoingBubbleImageData;
+@property (strong, nonatomic) JSQMessagesBubbleImage *incomingBubbleImageData;
+
+@end
+
+@implementation ConversationViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self initJsqUIAttributes];
+    [self registerForNotifications];
+    [self performRequest];
+}
+
+#pragma mark - Initializers
+
+- (void)initJsqUIAttributes {
+    self.title = self.viewModel.title;
+    self.senderId = [@(self.viewModel.senderId) stringValue];
+    self.senderDisplayName = self.viewModel.title;
+    
+    JSQMessagesBubbleImageFactory *bubbleFactory = [[JSQMessagesBubbleImageFactory alloc] init];
+    self.outgoingBubbleImageData = [bubbleFactory outgoingMessagesBubbleImageWithColor:[UIColor jsq_messageBubbleBlueColor]];
+    self.incomingBubbleImageData = [bubbleFactory incomingMessagesBubbleImageWithColor:[UIColor jsq_messageBubbleLightGrayColor]];
+    
+    self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;
+    self.collectionView.collectionViewLayout.outgoingAvatarViewSize = CGSizeZero;
+    self.collectionView.collectionViewLayout.messageBubbleFont = [UIFont fontWithName:@"HelveticaNeue" size:14];
+    self.inputToolbar.contentView.leftBarButtonItem = nil;
+    self.inputToolbar.contentView.textView.placeHolder = nil;
+    self.showLoadEarlierMessagesHeader = YES;
+    self.collectionView.loadEarlierMessagesHeaderTextColor = [UIColor blueColor];
+}
+
+- (void)initRecognizers {
+    self.recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    [self.collectionView addGestureRecognizer:self.recognizer];
+}
+
+#pragma mark - Notification methods
+
+- (void)registerForNotifications {
+    __weak typeof(self) weakSelf = self;
+    [[NSNotificationCenter defaultCenter] addObserverForName:PrivateMessageReceivedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+                                                      __strong typeof(self) strongSelf = weakSelf;
+                                                      [strongSelf.viewModel addMessage:notification.userInfo[@"message"]];
+                                                      [strongSelf.collectionView reloadData];
+                                                      [strongSelf scrollToBottomAnimated:YES];
+                                                  }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:PrivateMessageNotSentNoticifation
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+                                                      __strong typeof(self) strongSelf = weakSelf;
+                                                      [strongSelf.view makeToastWithText:notification.userInfo[@"error"]];
+                                                  }];
+}
+
+#pragma mark - <JSQMessageViewController>
+
+
+- (void)didPressSendButton:(UIButton *)button
+           withMessageText:(NSString *)text
+                  senderId:(NSString *)senderId
+         senderDisplayName:(NSString *)senderDisplayName
+                      date:(NSDate *)date {
+    [JSQSystemSoundPlayer jsq_playMessageSentSound];
+    [self.viewModel createMessage:text sentAt:[NSDate date]];
+    [self finishSendingMessageAnimated:YES];
+    [self scrollToBottomAnimated:YES];
+}
+
+#pragma mark - JSQMessages CollectionView DataSource
+
+- (id<JSQMessageBubbleImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView messageBubbleImageDataForItemAtIndexPath:(NSIndexPath *)indexPath {
+    MessageViewModel *messageViewModel = [self.viewModel objectAtIndex:indexPath.item];
+    return [self.viewModel isOutgoing:messageViewModel] ? self.outgoingBubbleImageData : self.incomingBubbleImageData;
+}
+
+- (id<JSQMessageData>)collectionView:(JSQMessagesCollectionView *)collectionView messageDataForItemAtIndexPath:(NSIndexPath *)indexPath {
+    MessageViewModel *viewModel = [self.viewModel objectAtIndex:indexPath.item];
+    return [viewModel jsqMessage];
+}
+
+- (id<JSQMessageAvatarImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView avatarImageDataForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return nil;
+}
+
+- (NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellTopLabelAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.item % MessagesBetweenDates == 0) {
+        MessageViewModel *viewModel = [self.viewModel objectAtIndex:indexPath.item];
+        return [viewModel dateAttributedString];
+    }
+    
+    return nil;
+}
+
+#pragma mark - UICollectionView DataSource
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return [self.viewModel count];
+}
+
+#pragma mark JSQMessages collection view flow layout delegate
+
+#pragma mark - Adjusting cell label heights
+
+- (CGFloat)collectionView:(JSQMessagesCollectionView *)collectionView
+                   layout:(JSQMessagesCollectionViewFlowLayout *)collectionViewLayout heightForCellTopLabelAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.item % MessagesBetweenDates == 0) {
+        return kJSQMessagesCollectionViewCellLabelHeightDefault;
+    }
+    
+    return 0.0f;
+}
+
+- (CGFloat)collectionView:(JSQMessagesCollectionView *)collectionView
+                   layout:(JSQMessagesCollectionViewFlowLayout *)collectionViewLayout heightForMessageBubbleTopLabelAtIndexPath:(NSIndexPath *)indexPath {
+    return kJSQMessagesCollectionViewCellLabelHeightDefault;
+}
+
+#pragma mark - Responding to collection view tap events
+
+- (void)collectionView:(JSQMessagesCollectionView *)collectionView
+                header:(JSQMessagesLoadEarlierHeaderView *)headerView didTapLoadEarlierMessagesButton:(UIButton *)sender {
+    [self performRequest];
+}
+
+- (void)collectionView:(JSQMessagesCollectionView *)collectionView didTapAvatarImageView:(UIImageView *)avatarImageView atIndexPath:(NSIndexPath *)indexPath {
+    [self dismissKeyboard];
+}
+
+- (void)collectionView:(JSQMessagesCollectionView *)collectionView didTapMessageBubbleAtIndexPath:(NSIndexPath *)indexPath {
+    [self dismissKeyboard];
+}
+
+- (void)collectionView:(JSQMessagesCollectionView *)collectionView didTapCellAtIndexPath:(NSIndexPath *)indexPath touchLocation:(CGPoint)touchLocation {
+    [self dismissKeyboard];
+}
+
+#pragma mark - Request methods
+
+- (void)performRequest {
+    [self.viewModel fetchMessages:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.collectionView reloadData];
+            [self scrollToBottomAnimated:NO];
+        });
+    } failure:^(NSString *errorMSG) {
+        [self.view makeToastWithText:errorMSG];
+    }];
+}
+
+#pragma mark - Recognizer actions
+
+- (void)dismissKeyboard {
+    if([self.inputToolbar.contentView.textView isFirstResponder]) {
+        [self.inputToolbar.contentView.textView resignFirstResponder];
+    }
+}
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/CollectionViewModel.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/CollectionViewModel.h
@@ -16,7 +16,7 @@
 
 - (instancetype)initWithAmountPerPage:(NSUInteger)amountPerPage;
 
-- (void)saveResources:(NSArray *)resources;
+- (void)addPage:(NSArray *)resources;
 
 - (id)objectAtIndex:(NSUInteger)index;
 
@@ -25,5 +25,9 @@
 - (NSUInteger)count;
 
 - (BOOL)isEndOfPage:(NSUInteger)index;
+
+- (void)addResource:(id)resource;
+
+- (void)addResource:(id)resource atIndex:(NSUInteger)index;
 
 @end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/CollectionViewModel.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/CollectionViewModel.m
@@ -19,7 +19,7 @@
 - (instancetype)initWithAmountPerPage:(NSUInteger)amountPerPage {
     self = [super init];
     if(self) {
-        _pageNumber = 1;
+        _pageNumber = 0;
         _isLastPage = NO;
         _resources = [NSMutableArray array];
         _amountPerPage = amountPerPage;
@@ -27,17 +27,26 @@
     return self;
 }
 
-- (void)saveResources:(NSArray *)resources {
+- (void)addPage:(NSArray *)resources {
     [self.resources addObjectsFromArray:resources];
+    _pageNumber++;
     if(resources.count < self.amountPerPage) {
         _isLastPage = YES;
     }
 }
 
+- (void)addResource:(id)resource {
+    [self.resources addObject:resource];
+}
+
+- (void)addResource:(id)resource atIndex:(NSUInteger)index {
+    [self.resources insertObject:resource atIndex:index];
+}
+
 - (void)reset {
     [self.resources removeAllObjects];
     _isLastPage = NO;
-    _pageNumber = 1;
+    _pageNumber = 0;
 }
 
 - (id)objectAtIndex:(NSUInteger)index {

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/MessageViewModel.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/MessageViewModel.h
@@ -1,0 +1,27 @@
+//
+//  MessageViewModel.h
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WLXQuickBloxUtils.h"
+#import "JSQMessages.h"
+
+@interface MessageViewModel : NSObject
+
+- (instancetype)initWithQBChatMessage:(QBChatMessage *)message;
+
+- (NSString *)text;
+- (NSUInteger)senderId;
+- (NSUInteger)recipientId;
+- (NSDate *)date;
+- (NSString *)qbMessageId;
+
+- (id<JSQMessageData>)jsqMessage;
+- (NSAttributedString *)dateAttributedString;
+- (NSAttributedString *)attributedTitle:(NSString *)title;
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/MessageViewModel.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/MessageViewModel.m
@@ -1,0 +1,67 @@
+//
+//  MessageViewModel.m
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/28/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import "MessageViewModel.h"
+
+@interface MessageViewModel ()
+
+@property (strong, nonatomic) QBChatMessage *message;
+
+@end
+
+@implementation MessageViewModel
+
+- (instancetype)initWithQBChatMessage:(QBChatMessage *)message {
+    self = [super init];
+    if(self) {
+        _message = message;
+    }
+    return self;
+}
+
+- (NSString *)text {
+    return _message.text;
+}
+
+- (NSUInteger)senderId {
+    return _message.senderID;
+}
+
+- (NSUInteger)recipientId {
+    return _message.recipientID;
+}
+
+- (NSDate *)date {
+    return _message.dateSent;
+}
+
+- (NSString *)qbMessageId {
+    return _message.ID;
+}
+
+#pragma mark - JSQMessage methods
+
+- (id<JSQMessageData>)jsqMessage {
+    return [[JSQMessage alloc] initWithSenderId:[@(_message.senderID) stringValue]
+                              senderDisplayName:@""
+                                           date:_message.dateSent
+                                           text:self.message.text ? self.message.text : @" "]; // JSQMessage crashes if message is null
+}
+
+- (NSAttributedString *)dateAttributedString {
+    return [[JSQMessagesTimestampFormatter sharedFormatter] attributedTimestampForDate:[self date]];
+}
+
+- (NSAttributedString *)attributedTitle:(NSString *)title {
+    if(!title) {
+        return nil;
+    }
+    return [[NSAttributedString alloc] initWithString:title];
+}
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/PrivateDialogViewModel.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/PrivateDialogViewModel.h
@@ -1,0 +1,37 @@
+//
+//  PrivateDialogViewModel.h
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/27/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "WLXQuickBloxUtils.h"
+#import "MessageViewModel.h"
+#import "UserViewModel.h"
+
+extern NSString *const PrivateMessageReceivedNotification;
+extern NSString *const PrivateMessageNotSentNoticifation;
+
+@interface PrivateDialogViewModel : NSObject
+
+@property (readonly, nonatomic) NSString *title;
+@property (readonly, nonatomic) NSUInteger senderId;
+
+- (instancetype)initWithDialog:(QBChatDialog *)dialog quickbloxUtils:(WLXQuickBloxUtils *)quickbloxUtils userViewModel:(UserViewModel *)userViewModel ;
+
+- (NSString *)lastMessage;
+- (NSString *)lastMessageDate;
+- (BOOL)isOutgoing:(MessageViewModel *)viewModel;
+
+- (MessageViewModel *)objectAtIndex:(NSUInteger)index;
+- (void)resetData;
+- (NSUInteger)count;
+- (void)addMessage:(NSString *)message receivedAt:(NSDate *)date;
+- (void)addMessage:(QBChatMessage *)message;
+
+- (void)createMessage:(NSString *)message sentAt:(NSDate *)dateSent;
+- (void)fetchMessages:(void (^)())success failure:(void(^)(NSString *))failure;
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/PrivateDialogViewModel.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/PrivateDialogViewModel.m
@@ -1,0 +1,150 @@
+//
+//  PrivateDialogViewModel.m
+//  WLXQuickBloxUtils-sample
+//
+//  Created by Damian on 7/27/15.
+//  Copyright (c) 2015 Wolox. All rights reserved.
+//
+
+#import "PrivateDialogViewModel.h"
+#import <DateTools.h>
+#import <ObjectiveSugar.h>
+#import "CollectionViewModel.h"
+#import "NSString+CapitalizeFirstWord.h"
+
+NSUInteger static MessagesAmountPerPage = 25;
+NSString *const PrivateMessageReceivedNotification = @"privateMessageReceived";
+NSString *const PrivateMessageNotSentNoticifation = @"privateMessageReceived";
+
+@interface PrivateDialogViewModel ()
+
+@property (strong, nonatomic) QBChatDialog *dialog;
+@property (strong, nonatomic) CollectionViewModel *collectionViewModel;
+@property (strong, nonatomic) UserViewModel *userViewModel;
+@property (strong, nonatomic) WLXQuickBloxUtils *quickbloxUtils;
+
+@end
+
+@implementation PrivateDialogViewModel
+
+- (instancetype)initWithDialog:(QBChatDialog *)dialog quickbloxUtils:(WLXQuickBloxUtils *)quickbloxUtils userViewModel:(UserViewModel *)userViewModel {
+    self = [super init];
+    if(self) {
+        _dialog = dialog;
+        _senderId = quickbloxUtils.currentUser.ID;
+        _title = userViewModel.email;
+        _collectionViewModel = [[CollectionViewModel alloc] initWithAmountPerPage:MessagesAmountPerPage];
+        _quickbloxUtils = quickbloxUtils;
+        _userViewModel = userViewModel;
+        [self registerForNotifications];
+    }
+    return self;
+}
+
+#pragma mark - Message attribute methods
+
+- (NSString *)lastMessage {
+    return self.dialog.lastMessageText;
+}
+
+- (NSString *)lastMessageDate {
+    return [self.dialog.lastMessageDate timeAgoSinceNow];
+}
+
+- (BOOL)isOutgoing:(MessageViewModel *)viewModel {
+    return viewModel.senderId != self.userViewModel.qbId;
+}
+
+#pragma mark - Request methods
+
+- (void)createMessage:(NSString *)message sentAt:(NSDate *)dateSent {
+    [self.quickbloxUtils sendMessageToDialog:self.dialog
+                                        text:message
+                               saveToHistory:YES];
+    [self addMessage:message receivedAt:dateSent];
+}
+
+- (void)fetchMessages:(void (^)())success failure:(void(^)(NSString *))failure {
+    __weak typeof(self) weakSelf = self;
+    [self.quickbloxUtils messagesWithDialogID:self.dialog.ID
+                                  queryParams:nil
+                                         page:self.collectionViewModel.pageNumber
+                                       amount:self.collectionViewModel.amountPerPage
+                                      success:^(NSArray *messages) {
+                                          __strong typeof(self) strongSelf = weakSelf;
+                                          [strongSelf.collectionViewModel addPage:[self mapMessagesToViewModels:messages]];
+                                          if(success) {
+                                              success();
+                                          }
+                                      } failure:^(NSError *error) {
+                                          if(failure) {
+                                              failure([NSLocalizedString(@"message_fetching_error", nil) capitalizeFirstWord]);
+                                          }
+                                      }];
+}
+
+#pragma mark - Collection handling methods
+
+- (MessageViewModel *)objectAtIndex:(NSUInteger)index {
+    NSUInteger maxIndex = self.collectionViewModel.count - 1;
+    return [self.collectionViewModel objectAtIndex:maxIndex - index];
+}
+
+- (void)resetData {
+    [self.collectionViewModel reset];
+}
+
+- (NSUInteger)count {
+    return self.collectionViewModel.count;
+}
+
+- (void)addMessage:(NSString *)message receivedAt:(NSDate *)date {
+    QBChatMessage *newMessage = [QBChatMessage new];
+    newMessage.text = message;
+    newMessage.dateSent = date;
+    [self.collectionViewModel addResource:[[MessageViewModel alloc] initWithQBChatMessage:newMessage] atIndex:0];
+}
+
+- (void)addMessage:(QBChatMessage *)message {
+    [self.collectionViewModel addResource:[[MessageViewModel alloc] initWithQBChatMessage:message] atIndex:0];
+}
+
+#pragma mark - Notification methods
+
+- (void)registerForNotifications {
+    [[NSNotificationCenter defaultCenter] addObserverForName:QBPrivateChatMessageReceivedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+                                                      [[NSNotificationCenter defaultCenter] postNotificationName:PrivateMessageReceivedNotification
+                                                                                                          object:nil
+                                                                                                        userInfo:@{@"message":notification.userInfo[@"message"]}];
+                                                  }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:QBPrivateChatMessageCreationFailedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+                                                      NSString *errorMSG = [NSLocalizedString(@"message_not_sent_error", nil) capitalizeFirstWord];
+                                                      [[NSNotificationCenter defaultCenter] postNotificationName:PrivateMessageNotSentNoticifation
+                                                                                                          object:nil
+                                                                                                        userInfo:@{@"error":errorMSG}];
+                                                  }];
+}
+
+#pragma mark - Private methods
+
+// This method works assuming the dialog is created with the name "userLogin1-userLogin2"
+- (NSString *)getUserName {
+    NSArray *names = [self.dialog.name split:@"-"];
+    return [names detect:^BOOL(NSString *name) {
+        return ![name isEqualToString:[QBSession currentSession].currentUser.login];
+    }];
+}
+
+- (NSArray *)mapMessagesToViewModels:(NSArray *)messages {
+    return [messages map:^id(QBChatMessage *message) {
+        return [[MessageViewModel alloc] initWithQBChatMessage:message];
+    }];
+}
+
+@end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserListViewModel.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserListViewModel.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "WLXQuickBloxUtils.h"
 #import "UserViewModel.h"
+#import "PrivateDialogViewModel.h"
 
 @interface UserListViewModel : NSObject
 
@@ -18,6 +19,7 @@
 
 - (void)fetchUsers:(void (^)())success failure:(void(^)(NSString *))failure;
 - (void)paginateIfNeeded:(NSUInteger)index success:(void (^)())success failure:(void(^)(NSString *))failure;
+- (void)createDialogWithUser:(UserViewModel *)userViewModel success:(void(^)(PrivateDialogViewModel *))success failure:(void(^)(NSString *))failure;
 
 - (UserViewModel *)objectAtIndex:(NSUInteger)index;
 - (void)resetData;

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserViewModel.h
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserViewModel.h
@@ -16,5 +16,6 @@
 - (instancetype)initWithQBUUser:(QBUUser *)user;
 
 - (NSString *)email;
+- (NSUInteger)qbId;
 
 @end

--- a/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserViewModel.m
+++ b/WLXQuickBloxUtils-sample/WLXQuickBloxUtils-sample/ViewModels/UserViewModel.m
@@ -30,4 +30,8 @@
     return self.user.login;
 }
 
+- (NSUInteger)qbId {
+    return self.user.ID;
+}
+
 @end


### PR DESCRIPTION
@guidomb 
## Sumary

**Trello card**: https://trello.com/c/nXyPLIzq/6-funcionalidad-pantalla-de-conversacion
- Conversation view model 
- Message view model
- Messages requests and Dialog creation request
- WLXQuickbloxUtils changes to receive a name for the dialog(works only for group dialogs) and notification names improved
- WLXQuickbloxUtils now provides a method to obtain the current user
- Collection view model starts from the page 0 and can add objects at any index
- User view model has a method that returns the user's quickblox ID
## Test Plan

No visual changes
## Screenshots

No visual changes
